### PR TITLE
docs: update README badge targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 > 📣 You can view our repository on specialized disease LLMs at [FreedomIntelligence/Awesome-Specialized-Medical-LLMs](https://github.com/FreedomIntelligence/Awesome-Specialized-Medical-LLMs)!
 
 <p>
-  <a href="https://github.com/FreedomIntelligence/Medical_NLP"><img src=https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg ></a>
-  <a href="https://github.com/FreedomIntelligence/Medical_NLP"><img src=https://img.shields.io/github/forks/FreedomIntelligence/Medical_NLP.svg?style=social ></a>
-  <a href="https://github.com/FreedomIntelligence/Medical_NLP"><img src=https://img.shields.io/github/stars/FreedomIntelligence/Medical_NLP.svg?style=social ></a>
-  <a href="https://github.com/FreedomIntelligence/Medical_NLP"><img src=https://img.shields.io/github/watchers/FreedomIntelligence/Medical_NLP.svg?style=social ></a>
+  <a href="https://github.com/FreedomIntelligence/Awesome-AI4Med"><img src=https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg ></a>
+  <a href="https://github.com/FreedomIntelligence/Awesome-AI4Med"><img src=https://img.shields.io/github/forks/FreedomIntelligence/Awesome-AI4Med.svg?style=social ></a>
+  <a href="https://github.com/FreedomIntelligence/Awesome-AI4Med"><img src=https://img.shields.io/github/stars/FreedomIntelligence/Awesome-AI4Med.svg?style=social ></a>
+  <a href="https://github.com/FreedomIntelligence/Awesome-AI4Med"><img src=https://img.shields.io/github/watchers/FreedomIntelligence/Awesome-AI4Med.svg?style=social ></a>
 </p>
 
 Table of Contents:


### PR DESCRIPTION
## Summary
- Update README badge links from the old `FreedomIntelligence/Medical_NLP` repository path to `FreedomIntelligence/Awesome-AI4Med`.
- Update the forks, stars, and watchers shield targets to use the current repository name.

## Motivation
The README notes that the project has been renamed from `Medical_NLP` to `Awesome-AI4Med`, but the badge links and shield targets still reference the old repository path. Pointing them at the current repository keeps the README metadata consistent with the project name.

## Verification
- Ran `git diff --check`.
- Checked that the README contains the updated `Awesome-AI4Med` badge, forks, stars, and watchers targets.

## Risk
Docs-only change. No runtime behavior is affected.
