### PR TITLE
Add TCGA and HEST Xenium virtual spatial transcriptomics datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Table of Contents:
 |`BreastStage`|[[arXiv](https://arxiv.org/abs/2606.04911)]|[[HF](https://www.modelscope.cn/datasets/YYangYang/BreastStage)]|1.86M|
 |`OpenMedReason`|[[arXiv](https://arxiv.org/pdf/2606.12169)]|[[HF](https://huggingface.co/datasets/neginb/OpenMedReason)]|193k|
 |`TCGA virtual ST atlas`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas)]|~28.7k slides / ~296M spots|
-|`HEST Xenium virtual ST`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics)]|59 slides / ~13M spots|
+|`HEST Xenium virtual ST`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics)]|59 slides / ~13.3M cells|
 
 
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Table of Contents:
 |`BreastStage`|[[arXiv](https://arxiv.org/abs/2606.04911)]|[[HF](https://www.modelscope.cn/datasets/YYangYang/BreastStage)]|1.86M|
 |`OpenMedReason`|[[arXiv](https://arxiv.org/pdf/2606.12169)]|[[HF](https://huggingface.co/datasets/neginb/OpenMedReason)]|193k|
 |`TCGA virtual ST atlas`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas)]|~28.7k slides / ~296M spots|
-|`HEST Xenium virtual ST`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics)]|59 slides / ~13.3M cells|
+|`HEST Xenium virtual ST`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics)]|59 samples / ~13.3M cells|
 
 
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Table of Contents:
 |`UniMed-5M`|[[arXiv](https://arxiv.org/abs/2510.15710)]|[[HF](https://huggingface.co/datasets/General-Medical-AI/UniMed-5M)]|5M|
 |`BreastStage`|[[arXiv](https://arxiv.org/abs/2606.04911)]|[[HF](https://www.modelscope.cn/datasets/YYangYang/BreastStage)]|1.86M|
 |`OpenMedReason`|[[arXiv](https://arxiv.org/pdf/2606.12169)]|[[HF](https://huggingface.co/datasets/neginb/OpenMedReason)]|193k|
+|`TCGA virtual ST atlas`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas)]|~28.7k slides / ~296M spots|
+|`HEST Xenium virtual ST`|[[medRxiv](https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1)]|[[HF](https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics)]|59 slides / ~13M spots|
 
 
 <div align="right">


### PR DESCRIPTION
## Summary
Add DeepSpot-M virtual spatial transcriptomics datasets to the Datasets section — predicted transcriptome-wide ST from H&E (ratschlab).

Happy to adjust placement/wording.

## Links
| Dataset | HF | Paper | Code |
|---|---|---|---|
| TCGA virtual spatial transcriptomics atlas | https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas | https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1 | https://github.com/ratschlab/DeepSpotM |
| HEST Xenium virtual spatial transcriptomics | https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics | https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1 | https://github.com/ratschlab/DeepSpotM |

## Notes
- Both are gated (CC-BY-NC-SA-4.0) on Hugging Face.
- Primary link is the HF dataset page; paper/code are DeepSpot-M.

Made with [Cursor](https://cursor.com)